### PR TITLE
(FIX) Retain Cycle Between SoftAskView and Manager

### DIFF
--- a/PleaseAllow.xcodeproj/project.pbxproj
+++ b/PleaseAllow.xcodeproj/project.pbxproj
@@ -466,6 +466,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MARKETING_VERSION = 1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.safetyculture.PleaseAllow;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -491,6 +492,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MARKETING_VERSION = 1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.safetyculture.PleaseAllow;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/PleaseAllow/Info.plist
+++ b/PleaseAllow/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/PleaseAllow/PermissionManagers/PermissionManager.swift
+++ b/PleaseAllow/PermissionManagers/PermissionManager.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// Common Protocol for all Permissions
-public protocol PermissionManager {
+public protocol PermissionManager: AnyObject {
     /// Returns the `MangerType` for the current Permission Manager
     var type            : PermissionManagerType      { get }
     
@@ -84,7 +84,7 @@ extension PermissionManager {
      The completion to be called when the request manager is finished with the request
      */
     
-    internal mutating func request(handler: Please.Reply? = nil) {
+  internal func request(handler: Please.Reply? = nil) {
         resultHandler = handler
         guard isAvailable && canRequest else { return }
         

--- a/PleaseAllow/SoftAsk/SoftAskView.swift
+++ b/PleaseAllow/SoftAsk/SoftAskView.swift
@@ -26,7 +26,8 @@ open class DeniedAlert: SoftAskView {
 private var sharedWindow: UIWindow?
 
 open class SoftAskView {
-    private var manager: PermissionManager?
+
+    private weak var manager: PermissionManager?
     
     internal var softAskViewController: SoftAskViewController!
     


### PR DESCRIPTION
The library had a retention cycle between `SoftAskVIew` descendants and their manager (`Camera`, `Contacts`, etc)
This PR introduces the resolution for that cycle. `manager` entity is expected to be an instance of a class (as it is now) and referred weakly from the `SoftAskView`.

| BEFORE | AFTER |
| -------- | ------- |
| <img width="1137" alt="Screen Shot 2022-02-24 at 4 09 20 pm" src="https://user-images.githubusercontent.com/85464452/155463438-7e707817-3b5c-4ccc-b844-3755bd962c58.png"> | <img width="1137" alt="Screen Shot 2022-02-24 at 4 10 29 pm" src="https://user-images.githubusercontent.com/85464452/155463486-0a2da654-8828-4738-b3f2-bdb5bef28ab1.png"> |
